### PR TITLE
Use torch's `inference_mode` instead of `no_grad`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 [Unreleased]: https://github.com/hopsparser/hopsparser/compare/v0.4.2...HEAD
 
+### Changed
+
+- Minimal Pytorch version is now `1.9.0`
+- Use `torch.inference_mode` instead of `toch.no_grad` over all the parser methods.
+
+
 ## [0.4.2] — 2022-04-08
 
 [0.4.2]: https://github.com/hopsparser/hopsparser/compare/v0.4.1...v0.4.2

--- a/hopsparser/parser.py
+++ b/hopsparser/parser.py
@@ -433,7 +433,7 @@ class BiAffineParser(nn.Module):
         overall_size = torch.zeros(1, dtype=torch.long, device=device)
         gloss = torch.zeros(1, dtype=torch.float, device=device)
 
-        with torch.no_grad():
+        with torch.inference_mode():
             for batch in dev_set:
                 overall_size += batch.sentences.content_mask.sum()
 
@@ -569,7 +569,7 @@ class BiAffineParser(nn.Module):
                     tagger_scores, arc_scores, lab_scores, batch, loss_fnc
                 )
 
-                with torch.no_grad():
+                with torch.inference_mode():
                     train_loss += loss
 
                 optimizer.zero_grad()
@@ -733,7 +733,7 @@ class BiAffineParser(nn.Module):
         self.eval()
         device = next(self.parameters()).device
 
-        with torch.no_grad():
+        with torch.inference_mode():
             for batch in batch_lst:
                 batch = batch.to(device)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "pyyaml",
     "rich",
     "sentencepiece",
-    "torch >= 1.8.1, < 1.12.0, != 1.10.0",
+    "torch >= 1.9.0, < 1.12.0, != 1.10.0",
     "transformers >= 4.12.2, < 5.0.0",
     "uvicorn",
 ]


### PR DESCRIPTION
New in Pytorch 1.9, [inference mode](https://pytorch.org/docs/1.11/generated/torch.inference_mode.html) is an alternative `no_grad` that applies more optimizations, for some speed gains, with trade-off that don't matter for us.